### PR TITLE
Adicionando comunicação Orientada a eventos com RabbitMQ 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,13 +22,19 @@ configurations {
 repositories {
 	mavenCentral()
 }
+ext {
+	set('springCloudVersion', "2024.0.1")
+	set('testcontainersVersion', "1.19.8")
+}
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.cloud:spring-cloud-stream-binder-rabbit'
 	implementation 'org.flywaydb:flyway-core:9.8.1'
 	implementation 'org.springframework:spring-jdbc'
+
 
 	compileOnly 'org.projectlombok:lombok'
 
@@ -46,8 +52,29 @@ dependencies {
 	testImplementation 'org.testcontainers:postgresql'
 	testImplementation 'org.testcontainers:r2dbc'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'org.springframework.cloud:spring-cloud-stream'
+	testImplementation 'org.springframework.cloud:spring-cloud-stream-test-binder'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+bootBuildImage {
+	imageName = "${project.name}"
+	environment = ["BP_JVM_VERSION": "17.*"]
+
+	docker {
+		publishRegistry {
+			username = project.findProperty("registryUsername")
+			password = project.findProperty("registryToken")
+			url = project.findProperty("registryUrl")
+		}
+	}
 }

--- a/src/main/java/com/polarbookshop/orderservice/domain/OrderService.java
+++ b/src/main/java/com/polarbookshop/orderservice/domain/OrderService.java
@@ -2,27 +2,37 @@ package com.polarbookshop.orderservice.domain;
 
 import com.polarbookshop.orderservice.book.Book;
 import com.polarbookshop.orderservice.book.BookClient;
+import com.polarbookshop.orderservice.event.OrderAcceptedMessage;
+import com.polarbookshop.orderservice.event.OrderDispatchedMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+@Slf4j
 @Service
 public class OrderService {
 
     private final OrderRepository orderRepository;
     private final BookClient bookClient;
+    private final StreamBridge streamBridge;
 
-    OrderService(OrderRepository orderRepository, BookClient bookClient) {
+    OrderService(OrderRepository orderRepository, BookClient bookClient, StreamBridge streamBridge) {
         this.bookClient = bookClient;
         this.orderRepository = orderRepository;
+        this.streamBridge = streamBridge;
     }
 
+    @Transactional
     public Mono<Order> submitOrder(String isbn, int quantity) {
 
         return bookClient.getBookByIsbn(isbn)
                 .map(book -> buildAcceptedOrder(book, quantity))
                 .defaultIfEmpty(buildRejectedOrder(isbn, quantity))
-                .flatMap(orderRepository::save);
+                .flatMap(orderRepository::save)
+                .doOnNext(this::publishOrderAcceptedEvent);
     }
 
     public static Order buildAcceptedOrder(Book book, int quantity) {
@@ -36,5 +46,31 @@ public class OrderService {
 
     public Flux<Order> getAllOrders() {
         return orderRepository.findAll();
+    }
+
+    public Flux<Order> consumeOrderDispatchedEvent(Flux<OrderDispatchedMessage> flux) {
+        return flux.flatMap(message ->
+                        orderRepository.findById(message.orderId()))
+                .map(this::buildDispatchedOrder)
+                .flatMap(orderRepository::save);
+    }
+
+    private Order buildDispatchedOrder(Order existingOrder) {
+        return new Order(existingOrder.id(), existingOrder.bookIsbn(), existingOrder.bookName(),
+                existingOrder.bookPrice(),
+                existingOrder.quantity(), OrderStatus.DISPATCHED,
+                existingOrder.createdDate(), existingOrder.lastModifiedDate(),
+                existingOrder.version());
+    }
+
+    private void publishOrderAcceptedEvent(Order order) {
+        if (!order.status().equals(OrderStatus.ACCEPTED)) {
+            return;
+        }
+        var orderAcceptedMessage = new OrderAcceptedMessage(order.id());
+        log.info("Enviando o pedido aceito event com id {}", order.id());
+
+        var result = streamBridge.send("acceptOrder-out-0", orderAcceptedMessage);
+        log.info("Resultado do pedido enviado com id {}: {}",order.id(), result);
     }
 }

--- a/src/main/java/com/polarbookshop/orderservice/event/OrderAcceptedMessage.java
+++ b/src/main/java/com/polarbookshop/orderservice/event/OrderAcceptedMessage.java
@@ -1,0 +1,6 @@
+package com.polarbookshop.orderservice.event;
+
+public record OrderAcceptedMessage(
+        Long orderId
+) {
+}

--- a/src/main/java/com/polarbookshop/orderservice/event/OrderDispatchedMessage.java
+++ b/src/main/java/com/polarbookshop/orderservice/event/OrderDispatchedMessage.java
@@ -1,0 +1,6 @@
+package com.polarbookshop.orderservice.event;
+
+public record OrderDispatchedMessage(
+        Long orderId
+) {
+}

--- a/src/main/java/com/polarbookshop/orderservice/event/OrderFunctions.java
+++ b/src/main/java/com/polarbookshop/orderservice/event/OrderFunctions.java
@@ -1,0 +1,27 @@
+package com.polarbookshop.orderservice.event;
+
+import com.polarbookshop.orderservice.domain.OrderService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.publisher.Flux;
+
+import java.util.function.Consumer;
+
+@Configuration
+public class OrderFunctions {
+
+    private static final Logger log =
+            LoggerFactory.getLogger(OrderFunctions.class);
+
+    @Bean
+    public Consumer<Flux<OrderDispatchedMessage>> dispatchOrder(OrderService orderService){
+
+        return flux ->
+                orderService.consumeOrderDispatchedEvent(flux)
+                        .doOnNext(order -> log.info("O pedido com id {} foi despachado ", order.id()))
+                        .subscribe();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,26 @@ spring:
         initial_interval: 1000
         max-interval: 2000
         multiplier: 1.1
+    function:
+      definition: dispatchOrder
+    stream:
+      bindings:
+        dispatchOrder-in-0:
+          destination: order-dispatched
+          group: ${spring.application.name}
+        acceptOrder-out-0:
+          destination: order-accepted
+      rabbitmq:
+        bindings:
+          acceptOrder-out-0:
+            producer:
+              transacted: true
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: user
+    password: password
+    connection-timeout: 5s
 polar:
   catalog-service-uri: "http://localhost:9001"
   temp-limit: 5


### PR DESCRIPTION
Adicionando comunicação Orientada a eventos utilizando RabbitMQ para enviar uma notificação ao serviço de CORREIOS que teve um pedido aceito e o applicativo se conecta novamente a uma QUEUE que informa que o pedido foi despachado e atualizar o status do pedido no banco de dados para despachado.
Utilizando o @Transactional para garantir que todo o fluxo está sendo respeitado e seguindo sua hierarquia, atualizando o pedido só depois que o correio informa que ele foi despachado, sem o @Transactional ele vai executar tudo sem respeitar a hierarquia dos metodos encadeados.