### PR TITLE
Configurando o kubernetes do edge-service para produção com implatanção

### DIFF
--- a/.github/workflows/acceptance-stage.yml
+++ b/.github/workflows/acceptance-stage.yml
@@ -7,7 +7,7 @@ on:
 concurrency: acceptance
 
 env:
-  OWNER: polarbookshop
+  OWNER: polar-libraries
   REGISTRY: ghcr.io
   APP_REPO: order-service
   DEPLOY_REPO: polar-deployment

--- a/.github/workflows/commit-stage.yml
+++ b/.github/workflows/commit-stage.yml
@@ -3,7 +3,7 @@ on: push
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: polarbookshop/order-service
+  IMAGE_NAME: polar-libraries/order-service
   VERSION: ${{ github.sha }}
 
 jobs:

--- a/k8s/application.yml
+++ b/k8s/application.yml
@@ -6,7 +6,7 @@ spring:
   flyway:
     url: jdbc:postgresql://polar-postgres/polardb_order
   rabbitmq:
-    host: localhost
+    host: polar-rabbitmq
   security:
     oauth2:
       resourceserver:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,8 +18,8 @@ spring:
       initial-size: 5
       max-size: 10
   flyway:
-    user: ${spring.r2dbc.username}
-    password: ${spring.r2dbc.password}
+    user: ${spring.r2dbc.username:user}
+    password: ${spring.r2dbc.password:password}
     url: jdbc:postgresql://localhost:5432/polardb_order
   config:
     import: ""


### PR DESCRIPTION
Configurando o kubernetes do edge-service para produção com implatanção continua notificando o workflow do polar-deployment para atualizar os pods com a nova imagem lançada. Implantação continua quando uma nova imagem candidatata é lançada e implatada automaticamente.